### PR TITLE
Fix: Users can now set the date to the first of the month

### DIFF
--- a/modules/calendar.mjs
+++ b/modules/calendar.mjs
@@ -182,7 +182,7 @@ export class Calendar extends Application {
       }
       let years = obj.year !== 0 ? obj.year : now.years;
       let months = obj.currentMonth;
-      let days = obj.day !== 0 ? obj.day : now.days;
+      let days = obj.day;
       Gametime.setAbsolute(now.setAbsolute({
         years,
         months,


### PR DESCRIPTION
Previously if you set the day to 1 it would just leave it at the current setting. This allows you to set day 1.